### PR TITLE
Mounting system

### DIFF
--- a/Drivers/FS.lua
+++ b/Drivers/FS.lua
@@ -1,0 +1,78 @@
+--[[
+	FS overwrite
+	Author: Wassil JAnssen a.k.a. Creator
+]]--
+
+--Variables
+local oldFS = fs
+
+--Functions
+function fs.isReadOnly(path)
+	path = fsh.resolveLinks(path)
+	return oldFS.isReadOnly(path)
+end
+
+function fs.list(path)
+	path = fsh.resolveLinks(path)
+	return oldFS.list(path)
+end
+
+function fs.exists(path)
+	path = fsh.resolveLinks(path)
+	return oldFS.exists(path)
+end
+
+function fs.isDir(path)
+	path = fsh.resolveLinks(path)
+	return oldFS.isDir(path)
+end
+
+function fs.getDrive(path)
+	path = fsh.resolveLinks(path)
+	return oldFS.getDrive(path)
+end
+
+function fs.getSize(path)
+	path = fsh.resolveLinks(path)
+	return oldFS.getSize(path)
+end
+
+function fs.getFreeSpace(path)
+	path = fsh.resolveLinks(path)
+	return oldFS.getFreeSpace(path)
+end
+
+function fs.makeDir(path)
+	path = fsh.resolveLinks(path)
+	return oldFS.makeDir(path)
+end
+
+function fs.copy(path1,path2)
+	path1 = fsh.resolveLinks(path1)
+	path2 = fsh.resolveLinks(path2)
+	return oldFS.copy(path1,path2)
+end
+
+function fs.move(path1,path2)
+	path1 = fsh.resolveLinks(path1)
+	path2 = fsh.resolveLinks(path2)
+	return oldFS.move(path1,path2)
+end
+
+function fs.delete(path)
+	path = fsh.resolveLinks(path)
+	return oldFS.delete(path)
+end
+
+function fs.open(path,mode)
+	path = fsh.resolveLinks(path)
+	return oldFS.open(path,mode)
+end
+
+function fs.getMount(path)
+	return fsh.resolveLinks(path)
+end
+
+function fs.mount(dst,src)
+	fsh.mount(dst,src)
+end

--- a/Drivers/Readme.md
+++ b/Drivers/Readme.md
@@ -1,0 +1,1 @@
+This file is going to be run on startup, after the apis are loaded.

--- a/core/lib/fsh.lua
+++ b/core/lib/fsh.lua
@@ -56,8 +56,3 @@ function resolveLinks(path)
 		return resolveLinks(resolved)
 	end
 end
-
---mount("OmniOS/Programs/FileX.app","disk1")
---mount("disk1","OmniOS/API")
---print(resolveLinks("OmniOS/Programs/FileX.app/Data/coo"))
---print(textutils.serialize(mounts))

--- a/core/lib/fsh.lua
+++ b/core/lib/fsh.lua
@@ -1,0 +1,63 @@
+--[[
+	VFS helper and moumting manager
+	Author: Wassil Janssen a.k.a. Creator
+]]--
+
+--Variables
+local mounts = {}
+local Internal = {}
+
+--Functions
+function Internal.getFirstElement(path)
+	return path:sub(1,path:find("/") and path:find("/")-1 or -1)
+end
+
+function Internal.makeTable(path,tabl)
+	if type(path) ~= "string" then error("Expected string, got "..type(path).."!",2) end
+	if type(tabl) ~= "table" then error("Expected table, got "..type(path).."!",2) end
+	path = fs.combine("",path)
+	local first = Internal.getFirstElement(path)
+	--print(first)
+	if first == path then
+		return tabl, first
+	else
+		if not tabl[first] then tabl[first] = {} end
+		return Internal.makeTable(path:sub(path:find("/")+1,-1),tabl[first])
+	end
+end
+
+function mount(destination,source)
+	if not fs.exists(destination) then fs.makeDir(destination) end
+	if not fs.exists(source) then fs.makeDir(source) end
+	local tabl, dir = Internal.makeTable(destination,mounts)
+	print(tabl)
+	print(dir)
+	tabl[dir] = source
+end
+
+function Internal.resolveLinks(path,tabl)
+	local first = Internal.getFirstElement(path)
+	if tabl[first] then
+		if type(tabl[first]) == "table" then
+			return Internal.resolveLinks(path:sub(path:find("/")+1,-1),tabl[first],start)
+		elseif type(tabl[first]) == "string" then
+			return tabl[first].."/"..path:sub(path:find("/")+1,-1)
+		end
+	end
+	print(first)
+	return false
+end
+
+function resolveLinks(path)
+	resolved = Internal.resolveLinks(path,mounts)
+	if resolved == false then
+		return path
+	else
+		return resolveLinks(resolved)
+	end
+end
+
+--mount("OmniOS/Programs/FileX.app","disk1")
+--mount("disk1","OmniOS/API")
+--print(resolveLinks("OmniOS/Programs/FileX.app/Data/coo"))
+--print(textutils.serialize(mounts))


### PR DESCRIPTION
I added a mounting system aswell as a fs overwrite.
In the drivers folder I specified that the file(s) it=n there have to be run after the APIs are loaded.
With these additions it is possible to mount a path by using:
`fs.mount(destination,source)`
Example: `fs.mount("OmniOS/Programs/FileX/Disk","disk1")`
Whenever I access OmniOS/Programs/FileX/Disk/something I get redierected to disk1/something.